### PR TITLE
Example notebook for NIRCam observers

### DIFF
--- a/jwst_rogue_path_tool/notebooks/nircam_observer_example.ipynb
+++ b/jwst_rogue_path_tool/notebooks/nircam_observer_example.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3057b9b9-9acf-4a6a-b665-b278dd843eec",
+   "metadata": {},
+   "source": [
+    "# NIRCam Observer Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f48d850-17a1-469f-bdb8-ed1dfba66e33",
+   "metadata": {},
+   "source": [
+    "This notebook will show how to run the rogue path tool on a NIRCam program to get the [position angle](https://jwst-docs.stsci.edu/jwst-observatory-characteristics-and-performance/jwst-position-angles-ranges-and-offsets#gsc.tab=0) (PA) ranges free from [claws](https://jwst-docs.stsci.edu/known-issues-with-jwst-data/nircam-known-issues/nircam-scattered-light-artifacts#NIRCamScatteredLightArtifacts-clawsClaws). It will also show how to incporporate these PA ranges into your APT program to ensure the observations are only taken within those PA ranges."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5aee8eb-a17d-4ac6-ac2d-0fe10b2f781e",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "1. [Imports](#1.-Imports)\n",
+    "2. [Input Data](#2.-Input-Data)\n",
+    "3. [Run the Tool](#3.-Run-the-Tool)\n",
+    "4. [Apply PA constraints to APT](#4.-Apply-PA-constraints-to-APT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16ee271d-a755-42d5-964b-96e0dbcfde9d",
+   "metadata": {},
+   "source": [
+    "## 1. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0131b0c7-c68c-4f8a-8da2-e8060d0928f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pathlib\n",
+    "\n",
+    "from jwst_rogue_path_tool.detect_claws import aptProgram\n",
+    "from jwst_rogue_path_tool.plotting import create_v3pa_vs_flux_plot\n",
+    "from jwst_rogue_path_tool.constants import PROJECT_DIRNAME"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c559307-99aa-4d2e-8c46-b30072579f43",
+   "metadata": {},
+   "source": [
+    "## 2. Input Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98c1f9f1-7920-45f9-a7a5-32968b9a55c0",
+   "metadata": {},
+   "source": [
+    "The tool requires the [APT records file](https://jwst-docs.stsci.edu/jwst-astronomers-proposal-tool-overview/additional-jwst-apt-functionality/apt-export-files#APTExportFiles-records_filerecordsfile) as input, which is a json file that contains various information on the pointing and instrument configuration for each observation in the program. This file can be obtained by opening the program in APT then `File->Export->records.json file`. For this notebook, we'll simply use the example records file already contained within this repository `APT_test_4RPtool.records.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c87836b6-58b9-4f57-b21d-dafb32099a12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apt_json_filename = pathlib.Path(PROJECT_DIRNAME) / \"data\" / \"APT_test_4RPtool.records.json\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3acd37e-d8c2-4f64-ad23-c1c4c640991f",
+   "metadata": {},
+   "source": [
+    "## 3. Run the Tool"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b68a3662-5251-408a-af36-70f63855d1dc",
+   "metadata": {},
+   "source": [
+    "Next, we'll run the tool on the example program to get the predicted claw flux at each possible position angle. We'll also write out the position angles that are free from claws into a text file. We'll save both of these outputs in the current working directory; the claw flux plots and text files will be saved in the `v3pa_vs_flux` and `valid_angle_reports` subdirectories, respectively. The below cell will run on all observations which will take ~5 minutes; to save time, you can also run all of these steps on a single observation of interest, as demonstrated in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fba0999d-32b0-4dc8-9974-064bcf80883c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the tool\n",
+    "program = aptProgram(apt_json_filename, angular_step=1.0)\n",
+    "program.run()\n",
+    "\n",
+    "# Get supported observations (i.e. omit non-imaging NIRCam modes or other instruments)\n",
+    "supported_observations = program.observations.supported_observations.keys()\n",
+    "\n",
+    "# For each observation, plot the predicted claw flux at each PA, and generate a text file showing the position angles free from claws\n",
+    "for obs_number in supported_observations:\n",
+    "    # Make plot of claws flux vs position angle\n",
+    "    create_v3pa_vs_flux_plot(program.observations.data[obs_number], output_directory=pathlib.Path(os.getcwd()))\n",
+    "    # Make file containing good position angles\n",
+    "    program.make_background_report(program.observations.data[obs_number], output_directory=os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50c4c37e-fb2e-493a-a644-9d7bf380f928",
+   "metadata": {},
+   "source": [
+    "Below, we show how to run the tool and get the outputs for a single observation. This time, we'll display the claw flux plots inline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07cce2c5-edcf-4677-8911-1c5092148e40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The observation number of interest\n",
+    "obs_number = 5\n",
+    "\n",
+    "# Run the tool\n",
+    "program = aptProgram(apt_json_filename, angular_step=1.0, usr_defined_obs=[obs_number])\n",
+    "program.run()\n",
+    "\n",
+    "# Make plot of claws flux vs position angle\n",
+    "create_v3pa_vs_flux_plot(program.observations.data[obs_number])\n",
+    "# Make file containing good position angles\n",
+    "program.make_background_report(program.observations.data[obs_number], output_directory=os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a86a6ead-1064-43e1-94ff-ee73accd9f44",
+   "metadata": {},
+   "source": [
+    "The plot above illustrates the predicted claw flux at each position angle for every filter. The horizontal orange and green lines indicate signal levels at 10% (based on minimum background throughout the year) and 20% (based on mean background throughout the year) of the predicted background levels, respectively. These thresholds help identify position angles free from claw contamination. Typically, the 20% threshold is sufficient, but for certain targets—such as faint, high-redshift objects—observers may prefer the more conservative 10% threshold. The PA ranges that are free from claws based on each threshold are saved to a text file, e.g. for this example observation `program_0_observation_5_background_module_B.txt`:\n",
+    "```\n",
+    "**** Ranges Not Impacted by Background Thresholds ****\n",
+    "**** Module B ****\n",
+    "**** Ranges Under 0.1 of min  ****\n",
+    "PA Start -- PA End: 0 -- 80\n",
+    "PA Start -- PA End: 103 -- 115\n",
+    "PA Start -- PA End: 126 -- 157\n",
+    "PA Start -- PA End: 162 -- 163\n",
+    "PA Start -- PA End: 184 -- 221\n",
+    "PA Start -- PA End: 243 -- 253\n",
+    "PA Start -- PA End: 263 -- 265\n",
+    "PA Start -- PA End: 270 -- 300\n",
+    "PA Start -- PA End: 310 -- 312\n",
+    "PA Start -- PA End: 315 -- 359\n",
+    "**** Ranges Under 0.2 of mean  ****\n",
+    "PA Start -- PA End: 0 -- 81\n",
+    "PA Start -- PA End: 92 -- 117\n",
+    "PA Start -- PA End: 124 -- 165\n",
+    "PA Start -- PA End: 178 -- 178\n",
+    "PA Start -- PA End: 183 -- 223\n",
+    "PA Start -- PA End: 235 -- 237\n",
+    "PA Start -- PA End: 240 -- 302\n",
+    "PA Start -- PA End: 308 -- 359\n",
+    "```\n",
+    "\n",
+    "The PA ranges in this file are determined conservatively by considering all filters together. If the predicted claw flux in any filter exceeds the threshold, the corresponding position angle is excluded from these ranges."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c36c5be-4fe2-4cfb-aa4e-b48a21a21a76",
+   "metadata": {},
+   "source": [
+    "## 4. Apply PA constraints to APT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1de1bfe2-e828-4d2f-816c-79a2f7e9c089",
+   "metadata": {},
+   "source": [
+    "Once the PA ranges free from claws are determined, users can add them to their APT files as a [PA Special Requirement](https://jwst-docs.stsci.edu/jppom/special-requirements/aperture-position-angle-special-requirements#gsc.tab=0) to ensure their observations are only taken within those PA ranges. To do this, select the observation in APT, then go to `Special Requirement->Add→Position Angle→PA Range` and input each good PA range in the V3PA Range boxes. Each PA range should be entered as a separate Special Requirement. For example, using the 20% threshold, the first Special Requierment for the example observation above would be:\n",
+    "```\n",
+    "Aperture PA Range 359.92542306 to 80.92542306 Degrees (V3 0.0 to 81.0)\n",
+    "```\n",
+    "\n",
+    "Currently, the tool does not take into account target visibility, so some of the PA ranges shown may not need to be considered. For example, if a strong claw is predicted at a PA that is never available in the [roll analysis](https://jwst-docs.stsci.edu/jwst-astronomers-proposal-tool-overview/apt-workflow-articles/apt-visit-planner#gsc.tab=0), users don't have to include Special Requirements to avoid that PA as it will never be used anyway. To check which PA ranges are actually available for a given visit, users can go to `Visit Planner->Reports->Visitx.x→Total Roll Analysis For Visit`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Example notebook for NIRCam observers, showing how to get PA ranges free from claws and apply them to their APT files.