### PR TITLE
Update filter/pupil lists for multiple pupil vals with same filter val

### DIFF
--- a/jwst_rogue_path_tool/detect_claws.py
+++ b/jwst_rogue_path_tool/detect_claws.py
@@ -667,8 +667,10 @@ class exposureFrames:
         filters = total_exposure_duration_table["filter_short"]
         pupils = get_pupil_from_filter(filters)
 
-        total_exposure_duration_table["filters"] = pupils.keys()
-        total_exposure_duration_table["pupils"] = pupils.values()
+        total_exposure_duration_table["filters"] = [e.split('+')[0] for e in pupils]
+        total_exposure_duration_table["pupils"] = [e.split('+')[1] for e in pupils]
+
+        print(total_exposure_duration_table)
 
         self.total_exposure_duration_table = total_exposure_duration_table
 

--- a/jwst_rogue_path_tool/detect_claws.py
+++ b/jwst_rogue_path_tool/detect_claws.py
@@ -250,7 +250,7 @@ class aptProgram:
                             flux_above_limit = np.copy(fluxes[flux_key])
                             limit_indices = flux_above_limit < lam_thresh
 
-                            flux_boolean_key = f"{filter}_{module}"
+                            flux_boolean_key = f"{pupil if pupil != 'CLEAR' else filter}_{module}"
                             statistics_key = f"{statistic_function.__name__}_{lam_thresh}_{threshold}"
                             flux_boolean[flux_boolean_key][statistics_key] = (
                                 limit_indices
@@ -669,8 +669,6 @@ class exposureFrames:
 
         total_exposure_duration_table["filters"] = [e.split('+')[0] for e in pupils]
         total_exposure_duration_table["pupils"] = [e.split('+')[1] for e in pupils]
-
-        print(total_exposure_duration_table)
 
         self.total_exposure_duration_table = total_exposure_duration_table
 

--- a/jwst_rogue_path_tool/plotting.py
+++ b/jwst_rogue_path_tool/plotting.py
@@ -386,7 +386,7 @@ def create_v3pa_vs_flux_plot(observation, output_directory=None, fontsize=15):
             axes[fltr, mod].plot(flux_values)
             above_threshold = np.copy(flux_values)
 
-            for color_idx, key in enumerate(flux_boolean[f"{filter}_{module}"].keys()):
+            for color_idx, key in enumerate(flux_boolean[f"{pupil if pupil != 'CLEAR' else filter}_{module}"].keys()):
                 stats_function, lam_threshold, bkg_threshold = key.split("_")
                 mask = flux_boolean[f"flux_boolean_{stats_function}_{module}"]
                 for other_module in modules:

--- a/jwst_rogue_path_tool/utils.py
+++ b/jwst_rogue_path_tool/utils.py
@@ -66,7 +66,6 @@ def get_pupil_from_filter(filters):
             filter = fltr
             pupil = "CLEAR"
 
-        pupils[filter] = pupil
         filt_pup.append(f'{filter}+{pupil}')
 
     return filt_pup

--- a/jwst_rogue_path_tool/utils.py
+++ b/jwst_rogue_path_tool/utils.py
@@ -51,7 +51,7 @@ def get_pupil_from_filter(filters):
     pupils : dict
         A dictionary of key (filter) and value (pupil)
     """
-    pupils = {}
+    filt_pup = []
 
     for fltr in filters:
         if "+" in fltr:
@@ -67,8 +67,9 @@ def get_pupil_from_filter(filters):
             pupil = "CLEAR"
 
         pupils[filter] = pupil
+        filt_pup.append(f'{filter}+{pupil}')
 
-    return pupils
+    return filt_pup
 
 
 def get_pivot_wavelength(pupil, filter):


### PR DESCRIPTION
This fixes a bug I found when running the tool on program 10108. In that case there is an observation where there are exposures with the same filter (F150W2) but different pupil-based filters (F164M and F162N). In this case, the tool crashed because get_filter_from_pupil() produced a dictionary with a F150W2 key and a F164M value, but without the F162N option (because it would need a duplicate key).  This then resulted in a dictionary with only 3 entries, but a pandas table with 4 rows. 

This PR changes get_filter_from_pupil to return a list, rather than a dictionary.